### PR TITLE
Change wording in Ruslan's Tower Task

### DIFF
--- a/Translated/Tasks/Side/Ruslan/ss0030771001.csv
+++ b/Translated/Tasks/Side/Ruslan/ss0030771001.csv
@@ -1,3 +1,3 @@
 Title#0,"""The Tower of Recollection"""
-Summary#0,"""Ruslan, a citizen of Retem City, tells you to climb the Tower of Recollection, just as Garoa once did."""
-text0101#0,"""Climb the Tower in Retem"""
+Summary#0,"""Ruslan, a citizen of Retem City, tells you to clear the Tower of Recollection, just as Garoa once did."""
+text0101#0,"""Clear the Tower in Retem"""


### PR DESCRIPTION
"Climb" has misled way too many people than it should have.

The japanese text used "踏破" which doesn't really imply "climb" in a literal sense so I think going with "clear" here is better.  
As usual, feel free to edit if there is a better word for this.